### PR TITLE
Check file types of arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ optional arguments:
                         parse verilog file and generate labeling template
   -o, --optimized       run verification in parallel
   -c <netlist> <order> <labeling> <mode>, --check <netlist> <order> <labeling> <mode>
-                        check if a netlist <netlist> is <order>-order secure
+                        check if a parsed netlist <netlist> is <order>-order secure
                         with the <labeling> as initial labeling; mode = s
                         (stable) | t (transient)
   -i <netlist> <order> <labeling>, --independence-check <netlist> <order> <labeling>
-                        check if a netlist <netlist> is <order>-order
+                        check if a parsed netlist <netlist> is <order>-order
                         independent with the <labeling> as initial labeling
 ```


### PR DESCRIPTION
Hi,
from the help page it wasn't fully clear to me that the parsed netlists have to be provided to the check commands. It took me a while to figure out what the problem was, so thought it would be a good idea to check the file types. This is what this PR does.
